### PR TITLE
remediate CVE-2021-33623

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,14 @@ const cli = meow(`
       Publish extension (with CLIENT_ID, CLIENT_SECRET, and REFRESH_TOKEN set as env variables)
       $ webstore publish --extension-id elomekmlfonmdhmpmdfldcjgdoacjcba
 `, {
-    string: ['_'],
-    default: {
-        source: process.cwd()
+    flags: {
+        _: {
+            type: 'string'
+        },
+        source: {
+            type: 'string',
+            default: process.cwd()
+        }
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chalk": "^1.1.3",
     "chrome-webstore-upload": "^0.4.3",
     "junk": "^1.0.2",
-    "meow": "^3.7.0",
+    "meow": "^5.0.0",
     "ora": "^0.2.3",
     "pify": "^2.3.0",
     "recursive-readdir": "^2.0.0",


### PR DESCRIPTION
Hi! First of all, thanks for making this package. Automating my addon publishing is delightful.

However, NPM currently complains about installing this package:
```
# npm audit report

trim-newlines  <3.0.1 || =4.0.0
Severity: high
Regular Expression Denial of Service - https://npmjs.com/advisories/1753
No fix available
node_modules/trim-newlines
  meow  3.4.0 - 5.0.0
  Depends on vulnerable versions of trim-newlines
  node_modules/meow
    chrome-webstore-upload-cli  *
    Depends on vulnerable versions of meow
    node_modules/chrome-webstore-upload-cli
```
so I've attempted to upgrade the `meow` dependency to a not-vulnerable version.

I believe I've updated the syntax correctly as per [`meow@v4`'s release notes](https://github.com/sindresorhus/meow/releases/tag/v4.0.0).

Tested and working as expected:
- [x] `npx webstore` (shows help, complains that I `Must specify "upload" or "publish"`) 
- [x] `npx webstore --help` (shows help, doesn't complain)
- [x] `webstore upload --source=src/` via package script (complains that `Option "extensionId" is required`)

Not tested because I don't have any private Chrome extensions to test it on:
- `webstore upload --source=src/` with required options for actual operation