### PR TITLE
Add support for absolute paths

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -8,7 +8,7 @@ const isZip = filepath => path.extname(filepath) === '.zip';
 
 export async function upload({ apiConfig, zipPath, token }) {
     const client = getClient(apiConfig);
-    const fullPath = path.join(process.cwd(), zipPath);
+    const fullPath = path.resolve(process.cwd(), zipPath);
     const zipStream = isZip(fullPath)
         ? fs.createReadStream(fullPath)
         : await zipdir(zipPath);


### PR DESCRIPTION
Method `upload` is now using `path.resolve` instead of `path.join`
- Fixes #68 